### PR TITLE
fix: rename graph nodes to avoid LangGraph 0.4.8 state key conflicts …

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -264,16 +264,16 @@ def itinerary_agent(state: TripState) -> TripState:
 
 def build_graph():
     g = StateGraph(TripState)
-    g.add_node("research", research_agent)
-    g.add_node("budget", budget_agent)
-    g.add_node("local", local_agent)
-    g.add_node("itinerary", itinerary_agent)
+    g.add_node("research_node", research_agent)
+    g.add_node("budget_node", budget_agent)
+    g.add_node("local_node", local_agent)
+    g.add_node("itinerary_node", itinerary_agent)
 
-    g.add_edge(START, "research")
-    g.add_edge("research", "budget")
-    g.add_edge("budget", "local")
-    g.add_edge("local", "itinerary")
-    g.add_edge("itinerary", END)
+    g.add_edge(START, "research_node")
+    g.add_edge("research_node", "budget_node")
+    g.add_edge("budget_node", "local_node")
+    g.add_edge("local_node", "itinerary_node")
+    g.add_edge("itinerary_node", END)
 
     return g.compile(checkpointer=MemorySaver())
 


### PR DESCRIPTION
…(serial)

- Renamed nodes from 'research', 'budget', 'local', 'itinerary' to 'research_node', 'budget_node', 'local_node', 'itinerary_node'
- Fixes ValueError: node name already being used as state key
- Maintains serial execution: research → budget → local → itinerary

🤖 Generated with Claude Code